### PR TITLE
Addded code to avoid parsing of escaped delimiters

### DIFF
--- a/lib/katex2html/parser.rb
+++ b/lib/katex2html/parser.rb
@@ -20,7 +20,7 @@ module Katex2HTML
     def each_delimiter
       parsed_html = ""
       @options[:delimiters].each do |rx|
-        regex = "#{Regexp.escape(rx[0])}+(.*?)#{Regexp.escape(rx[1])}+"
+        regex = "([^\\\\]#{Regexp.escape(rx[0])}+)(.*?)([^\\\\]#{Regexp.escape(rx[1])}+)"
         parsed_html = yield(regex, rx[0], rx[1])
       end
       parsed_html

--- a/spec/katex2html/parser_spec.rb
+++ b/spec/katex2html/parser_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Katex2HTML::Parser do
   let(:html_with_latex) { "<p>$log_{ab}$ and $log_{bc}$</p>" }
   let(:html_without_latex) { "<p>only text</p>" }
+  let(:html_with_money) { "<p>only text with U\\$20 and R\\$500,00</p>" }
 
   describe '#initialize' do
     it 'expects html param to initialize' do
@@ -45,6 +46,12 @@ describe Katex2HTML::Parser do
       it 'parses a HTML and returns original file' do
         parsed_html = Katex2HTML::Parser.new(html_without_latex).parse
         expect(parsed_html).to eq(html_without_latex)
+      end
+    end
+    context 'when HTML contains escaped currency symbol ($)' do
+      it 'does not generate Katex rendered content' do
+        parsed_html = Katex2HTML::Parser.new(html_with_money).parse
+        expect(parsed_html).to_not include('class="katex"')
       end
     end
   end


### PR DESCRIPTION
Sometimes in the content we need to use currency symbol ($) and it is the default delimiter. Before this patch, using currency are breaking the application.
