### PR TITLE
Fix escaped delimiters being matched 

### DIFF
--- a/lib/katex2html/parser.rb
+++ b/lib/katex2html/parser.rb
@@ -30,7 +30,7 @@ module Katex2HTML
     def each_delimiter
       parsed_html = ""
       @options[:delimiters].each do |rx|
-        regex = "([^\\\\]#{Regexp.escape(rx[0])}+)(.*?)([^\\\\]#{Regexp.escape(rx[1])}+)"
+        regex = "(?<!\\\\)(#{Regexp.escape(rx[0])}+)(.*?)(#{Regexp.escape(rx[1])}+)(?<!\\\\)"
         parsed_html = yield(regex, rx[0], rx[1])
       end
       parsed_html


### PR DESCRIPTION
With the older regex matcher, the closest before and after characters was being matched. This PR fixes using negative lookups to avoid them.
